### PR TITLE
Restore home directory access

### DIFF
--- a/io.github.troyeguo.koodo-reader.yml
+++ b/io.github.troyeguo.koodo-reader.yml
@@ -14,6 +14,8 @@ finish-args:
   - --share=network
   - --socket=x11
   - --socket=pulseaudio
+  # It uses old Electron and thus doesn't support GTKFileChooserNative
+  - --filesystem=home:ro
 cleanup:
   - /bin/*.py
   - /include


### PR DESCRIPTION
It still uses old Electron and requires the `home` directory access

Reverts https://github.com/flathub/io.github.troyeguo.koodo-reader/commit/e4574b170bfc252a2459edcc2a7edf3f14539040